### PR TITLE
MutationError::NetworkFull

### DIFF
--- a/src/client_errors.rs
+++ b/src/client_errors.rs
@@ -50,4 +50,7 @@ pub enum MutationError {
     Unknown,
     /// Request timed-out waiting for response.
     Timeout,
+    /// The loss of sacrificial copies indicates the network as a whole is no longer having
+    /// enough space to accept further put request. Have to wait more nodes to join.
+    NetworkFull,
 }


### PR DESCRIPTION
Affects: client_error.rs only

Put in a new MutationError to allow vault notify client network is full

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_network_common/9)

<!-- Reviewable:end -->
