### PR TITLE
feat/errors: make errors implement std error

### DIFF
--- a/src/client_errors.rs
+++ b/src/client_errors.rs
@@ -15,20 +15,47 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
+/// Errors in Get (non-mutating) operations involving Core and Vaults
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, RustcEncodable, RustcDecodable)]
-/// Errors in GET (non-mutating) operations involving Core and Vaults
 pub enum GetError {
     /// SAFE Account does not exist for client
     NoSuchAccount,
     /// Requested data not found
     NoSuchData,
-    /// Unknown error - Errors occuring at Vault level which have no bearing on clients, eg.
-    /// misc errors like serialisation failure, db failure etc
-    Unknown,
+    /// Network error occurring at Vault level which has no bearing on clients, e.g. serialisation
+    /// failure or database failure
+    NetworkOther(String),
 }
 
+impl Display for GetError {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match *self {
+            GetError::NoSuchAccount => write!(formatter, "Account does not exist for client"),
+            GetError::NoSuchData => write!(formatter, "Requested data not found"),
+            GetError::NetworkOther(ref error) => {
+                write!(formatter, "Error on Vault network: {}", error)
+            }
+        }
+    }
+}
+
+impl Error for GetError {
+    fn description(&self) -> &str {
+        match *self {
+            GetError::NoSuchAccount => "No such account",
+            GetError::NoSuchData => "No such data",
+            GetError::NetworkOther(ref error) => error,
+        }
+    }
+}
+
+
+
+/// Errors in Put/Post/Delete (mutating) operations involving Core and Vaults
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, RustcEncodable, RustcDecodable)]
-/// Errors in PUT/POST/DELETE (mutating) operations involving Core and Vaults
 pub enum MutationError {
     /// SAFE Account does not exist for client
     NoSuchAccount,
@@ -40,15 +67,58 @@ pub enum MutationError {
     DataExists,
     /// Insufficient balance for performing a given mutating operation
     LowBalance,
-    /// Invalid successor for performing a given mutating operation, e.g. signature mismatch,
-    /// invalid data versioning etc.
+    /// Invalid successor for performing a given mutating operation, e.g. signature mismatch or
+    /// invalid data versioning
     InvalidSuccessor,
-    /// Invalid Operation such as a POST on ImmutableData etc
+    /// Invalid Operation such as a POST on ImmutableData
     InvalidOperation,
-    /// Unknown error - Errors occuring at Vault level which have no bearing on clients, eg.
-    /// misc errors like serialisation failure, db failure etc
-    Unknown,
     /// The loss of sacrificial copies indicates the network as a whole is no longer having
-    /// enough space to accept further put request. Have to wait more nodes to join.
+    /// enough space to accept further put request so have to wait for more nodes to join
     NetworkFull,
+    /// Network error occurring at Vault level which has no bearing on clients, e.g. serialisation
+    /// failure or database failure
+    NetworkOther(String),
+}
+
+impl Display for MutationError {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match *self {
+            MutationError::NoSuchAccount => write!(formatter, "Account does not exist for client"),
+            MutationError::AccountExists => write!(formatter, "Account already exists for client"),
+            MutationError::NoSuchData => write!(formatter, "Requested data not found"),
+            MutationError::DataExists => write!(formatter, "Data given already exists"),
+            MutationError::LowBalance => {
+                write!(formatter, "Insufficient account balance for this operation")
+            }
+            MutationError::InvalidSuccessor => {
+                write!(formatter,
+                       "Data given is not a valid successor of stored data")
+            }
+            MutationError::InvalidOperation => {
+                write!(formatter, "Requested operation is not allowed")
+            }
+            MutationError::NetworkFull => {
+                write!(formatter, "Network cannot store any further data")
+            }
+            MutationError::NetworkOther(ref error) => {
+                write!(formatter, "Error on Vault network: {}", error)
+            }
+        }
+    }
+}
+
+impl Error for MutationError {
+    fn description(&self) -> &str {
+        match *self {
+            MutationError::NoSuchAccount => "No such account",
+            MutationError::AccountExists => "Account exists",
+            MutationError::NoSuchData => "No such data",
+            MutationError::DataExists => "Data exists",
+            MutationError::LowBalance => "Low account balance",
+            MutationError::InvalidSuccessor => "Invalid data successor",
+            MutationError::InvalidOperation => "Invalid operation",
+            MutationError::NetworkFull => "Network full",
+            MutationError::NetworkOther(ref error) => error,
+        }
+    }
 }

--- a/src/messaging/error.rs
+++ b/src/messaging/error.rs
@@ -15,6 +15,9 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use std::error::Error as StdError;
+use std::fmt::{self, Display, Formatter};
+
 use maidsafe_utilities::serialisation::SerialisationError;
 
 /// Error types relating to MPID messaging.
@@ -28,6 +31,33 @@ pub enum Error {
     BodyTooLarge,
     /// Serialisation error.
     Serialisation(SerialisationError),
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        match *self {
+            Error::MetadataTooLarge => write!(formatter, "Message header too large"),
+            Error::BodyTooLarge => write!(formatter, "Message body too large"),
+            Error::Serialisation(ref error) => write!(formatter, "Serialisation error: {}", error),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::MetadataTooLarge => "Header too large",
+            Error::BodyTooLarge => "Body too large",
+            Error::Serialisation(ref error) => error.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        match *self {
+            Error::Serialisation(ref error) => Some(error),
+            _ => None,
+        }
+    }
 }
 
 impl From<SerialisationError> for Error {


### PR DESCRIPTION
This implements the `std::error::Error` trait for the library's error types.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/safe_network_common/14)

<!-- Reviewable:end -->
